### PR TITLE
Add I6HRC and P8 Infinitime information

### DIFF
--- a/soc-list/nordic-semiconductor/i6hrc.md
+++ b/soc-list/nordic-semiconductor/i6hrc.md
@@ -15,3 +15,15 @@ I6HRC smartwatch
 | Vendor | Price | URL |
 |-|-:|-|
 |  |  |  |
+
+## Development Efforts
+### chrzwatch-firmware
+- https://github.com/StarGate01/chrzwatch-firmware
+- Written by [Christoph Honal](https://github.com/StarGate01/)
+- Based on the Mbed framework
+- Supported by an [Android GadgetBridge fork](https://codeberg.org/StarGate01/Gadgetbridge/src/branch/chrzwatch)
+
+### ATCNETZ
+- https://atcnetz.blogspot.com/2019/02/arduino-auf-dem-fitness-tracker-dank.html
+- Written by [Aaron Christophel](https://github.com/atc1441/)
+- Based on the Arduino Framework

--- a/soc-list/nordic-semiconductor/p8.md
+++ b/soc-list/nordic-semiconductor/p8.md
@@ -56,9 +56,11 @@ ___
 - An Arduino based firmware based off ATCwatch
 - Useful as a documentation resource to see how ATCwatch works, since a lot of the code is reused and explained
 
-### PineTime Development
+### InfiniTime
+- https://github.com/InfiniTimeOrg/InfiniTime
 - Since the hardware is shared with the PineTime, a lot of the development effort put into that device can be used for the P8
-- InfiniTime port to P8 in beta stage: [Link](https://github.com/JF002/InfiniTime/issues/62)
+- InfiniTime port to P8 in beta stage: [Issue](https://github.com/JF002/InfiniTime/issues/62), [Pull Request](https://github.com/InfiniTimeOrg/InfiniTime/pull/1050)
+- Pre-built binaries are available [here](https://github.com/StarGate01/p8b-infinitime)
 - See [the PineTime wiki](https://wiki.pine64.org/index.php/PineTime) for more information
 
 ___


### PR DESCRIPTION
This PR add links to projects for the I6HRC watch, and clarifies the state of the P8 Infinitime port.